### PR TITLE
add the missing definitions

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -32,7 +32,9 @@ target("levilamina-plugin-template") -- Change this to your plugin name.
         "UNICODE",
         "WIN32_LEAN_AND_MEAN",
         "ENTT_PACKED_PAGE=128",
-        "_HAS_CXX23=1"
+        "_HAS_CXX23=1",
+        "_HAS_CXX20=1",
+        "_HAS_CXX17=1"
     )
     add_files(
         "src/**.cpp"


### PR DESCRIPTION
## What does this PR do?

fix compiling
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\vcruntime.h(306): fatal error C1189: #error:  _HAS_CXX23 must imply _HAS_CXX20.
```

## Which issues does this PR resolve?



## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows [LeviLamina C++ Style Guide](https://github.com/LiteLDev/LeviLamina/wiki/CPP-Style-Guide)
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
