### PR TITLE
fix: fix compile

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -23,14 +23,14 @@ target("my-plugin") -- Change this to your plugin name.
         "/w44738",
         "/w45204"
     )
-    add_defines("NOMINMAX", "UNICODE")
+    add_defines("NOMINMAX", "UNICODE", "_HAS_CXX23=1")
     add_files("src/**.cpp")
     add_includedirs("src")
     add_packages("levilamina")
     add_shflags("/DELAYLOAD:bedrock_server.dll") -- To use symbols provided by SymbolProvider.
     set_exceptions("none") -- To avoid conflicts with /EHa.
     set_kind("shared")
-    set_languages("c++23")
+    set_languages("c++20")
     set_symbols("debug")
 
     after_build(function (target)

--- a/xmake.lua
+++ b/xmake.lua
@@ -30,7 +30,7 @@ target("my-plugin") -- Change this to your plugin name.
     add_shflags("/DELAYLOAD:bedrock_server.dll") -- To use symbols provided by SymbolProvider.
     set_exceptions("none") -- To avoid conflicts with /EHa.
     set_kind("shared")
-    set_languages("c++20")
+    set_languages("c++23")
     set_symbols("debug")
 
     after_build(function (target)


### PR DESCRIPTION
## What does this PR do?

fix compile
some class like mce::Blob can't be compile in c++20 without define _HAS_CXX23=1

## Which issues does this PR resolve?



## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows [LeviLamina C++ Style Guide](https://github.com/LiteLDev/LeviLamina/wiki/CPP-Style-Guide)
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
